### PR TITLE
fix: remover svg que deveria ser utilizado em tema light

### DIFF
--- a/src/components/HeroPattern.tsx
+++ b/src/components/HeroPattern.tsx
@@ -19,13 +19,6 @@ export function HeroPattern() {
             className="absolute inset-x-0 inset-y-[-50%] h-[200%] w-full skew-y-[-18deg] fill-black/40 stroke-black/50 mix-blend-overlay dark:fill-white/2.5 dark:stroke-white/5"
           />
         </div>
-        <svg
-          viewBox="0 0 1113 440"
-          aria-hidden="true"
-          className="absolute top-0 left-1/2 ml-[-19rem] w-[69.5625rem] fill-white blur-[26px] dark:hidden"
-        >
-          <path d="M.016 439.5s-9.5-300 434-300S882.516 20 882.516 20V0h230.004v439.5H.016Z" />
-        </svg>
       </div>
     </div>
   )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45896324/227391948-cbf63821-1cb5-4473-ac74-70ea4afa3f22.png)
